### PR TITLE
Deploy to azure fix

### DIFF
--- a/ProductionSchedule/Web.Release.config
+++ b/ProductionSchedule/Web.Release.config
@@ -3,23 +3,14 @@
 <!-- For more information on using Web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
 
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
-    <connectionStrings>
-      <add name="DefaultConnection" 
-        connectionString="[Will be replaced by Windows Azure Web Sites runtime]"
-        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
-    </connectionStrings>
   <system.web>
     <compilation xdt:Transform="RemoveAttributes(debug)" />
   </system.web>
   <entityFramework xdt:Transform="Replace">
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
     <contexts>
-      <context type="DownloadThis.Models.DownloadThisDb, DownloadThisDb">
-        <databaseInitializer type="System.Data.Entity.MigrateDatabaseToLatestVersion">
-          <parameters>
-            <parameter value="DownloadThisDb_DatabasePublish" />
-          </parameters>
-        </databaseInitializer>
+      <context type="ProductionSchedule.Models.ProductionScheduleContext, ProductionSchedule">
+        <databaseInitializer type="System.Data.Entity.MigrateDatabaseToLatestVersion`2[[ProductionSchedule.Models.ProductionScheduleContext, ProductionSchedule], [ProductionSchedule.Migrations.Configuration, ProductionSchedule]], EntityFramework" />
       </context>
     </contexts>
   </entityFramework>

--- a/ProductionSchedule/Web.config
+++ b/ProductionSchedule/Web.config
@@ -9,7 +9,7 @@
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
   </configSections>
   <connectionStrings>
-    <add name="DefaultConnection" providerName="System.Data.SqlClient" connectionString="Data Source=(LocalDb)\v11.0;Initial Catalog=aspnet-ProductionSchedule-20131017221821;Integrated Security=SSPI;AttachDBFilename=|DataDirectory|\aspnet-ProductionSchedule-20131017221821.mdf" />
+    <add name="ProductionScheduleContext" providerName="System.Data.SqlClient" connectionString="Data Source=(LocalDb)\v11.0;Initial Catalog=aspnet-ProductionSchedule-20131017221821;Integrated Security=SSPI;AttachDBFilename=|DataDirectory|\aspnet-ProductionSchedule-20131017221821.mdf" />
   </connectionStrings>
   <appSettings>
     <add key="webpages:Version" value="2.0.0.0" />


### PR DESCRIPTION
I'm able to deploy to azure Websites and have it override a connection string in the website from the portal after these changes.
I've changed the database initializer transform to refer to our context etc.
I've changed the Connection string name to ProductionScheduleContext. In my testing, I haven't been able to create a new connection string just using it in the portal (I suspect it lacks the information specified in the providerName attribute): it has to override one. I've also tested overriding one named DefaultConnection and this still results in an error about connecting to the instance.

To deploy with these changes, there needs to be a connection string named ProductionScheduleContext under the Configure tab for the Website in the portal.
