### PR TITLE
Fix data seeding

### DIFF
--- a/ProductionSchedule/Migrations/Configuration.cs
+++ b/ProductionSchedule/Migrations/Configuration.cs
@@ -18,6 +18,7 @@ namespace ProductionSchedule.Migrations
             context.Allocations.AddOrUpdate(p => p.AllocationId,
                new Allocation
                {
+                   AllocationId = 1,
                    Account = "Talk Talk Business",
                    Title = "Home page template",
                    Date = DateTime.Now,
@@ -26,6 +27,7 @@ namespace ProductionSchedule.Migrations
                },
                new Allocation
                {
+                   AllocationId = 2,
                    Account = "ICO",
                    Title = "Landing page template",
                    Date = DateTime.Now,


### PR DESCRIPTION
Data seeding was creating the same data each time the migrations run so you end up with duplicates. Have explicitly stated AllocationId (the field specified as the identifier in the AddOrUpdate call - EF uses this to decide whether to do an update or add)